### PR TITLE
Wallet restoration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*firebase*
 .eslintcache
 
 # Jest coverage outputs

--- a/src/boot/route-guard.js
+++ b/src/boot/route-guard.js
@@ -2,13 +2,11 @@
 /* eslint-disable */
 export default ({ router, store }) => {
   router.beforeEach((to, from, next) => {
+    // Check if user has opened a wallet
     const isLoggedIn = store.state.main.wallet?.address;
-    if (
-      isLoggedIn ||
-      to.name === 'home' ||
-      to.name === 'createWallet' ||
-      to.name === 'openWallet'
-    ) {
+    // Define list of page names that don't require login to access
+    const publicPages = ['home', 'createWallet', 'openWallet', 'restoreWallet'];
+    if (isLoggedIn || publicPages.includes(to.name)) {
       next();
     } else {
       next({ name: 'home' });

--- a/src/components/BaseInput.vue
+++ b/src/components/BaseInput.vue
@@ -2,6 +2,7 @@
   <div>
     <q-input
       v-model="content"
+      :autogrow="autogrow"
       color="primary"
       class="q-my-sm"
       :dense="dense"
@@ -28,6 +29,12 @@ export default Vue.extend({
   name: 'BaseInput',
 
   props: {
+    autogrow: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+
     dense: {
       type: Boolean,
       required: false,

--- a/src/pages/WalletCreate.vue
+++ b/src/pages/WalletCreate.vue
@@ -29,12 +29,7 @@
           :loading="isLoading"
           type="submit"
         />
-        <base-button
-          :flat="true"
-          :dense="true"
-          label="I have a wallet"
-          @click="$router.push({ name: 'openWallet' })"
-        />
+        <base-button :flat="true" :dense="true" label="I have a wallet" @click="navigate" />
       </div>
     </q-form>
   </q-page>
@@ -84,6 +79,19 @@ export default Vue.extend({
       } catch (err) {
         this.isLoading = false;
         this.showError(err);
+      }
+    },
+
+    /**
+     * @notice Takes user to the open page if data exists in local storage, and the
+     * restore page otherwise
+     */
+    async navigate() {
+      const hasWallet = Boolean(this.$q.localStorage.getItem('kaspa-wallet-data'));
+      if (hasWallet) {
+        await this.$router.push({ name: 'openWallet' });
+      } else {
+        await this.$router.push({ name: 'restoreWallet' });
       }
     },
   },

--- a/src/pages/WalletOpen.vue
+++ b/src/pages/WalletOpen.vue
@@ -1,7 +1,7 @@
 <template>
   <q-page padding class="text-primary page-margin">
     <q-form @submit="handleOpen">
-      <p class="primary">Unlock the wallet with your password</p>
+      <p class="text-primary">Unlock the wallet with your password</p>
       <base-input
         v-model="password"
         hint="Enter your password"
@@ -22,6 +22,12 @@
           :dense="true"
           label="New wallet"
           @click="$router.push({ name: 'createWallet' })"
+        />
+        <base-button
+          :flat="true"
+          :dense="true"
+          label="Restore wallet"
+          @click="$router.push({ name: 'restoreWallet' })"
         />
       </div>
     </q-form>

--- a/src/pages/WalletRestore.vue
+++ b/src/pages/WalletRestore.vue
@@ -32,9 +32,9 @@
         <q-card-section class="q-pt-none">
           <q-form @submit="decryptFile">
             <q-file
+              v-model="seedFile"
               accept=".dag"
               outlined
-              v-model="seedFile"
               hint="File must have a .dag extension"
               label="Select File"
               style="min-width: 275px;"
@@ -82,11 +82,15 @@
 
         <q-card-section class="q-pt-none">
           <q-form @submit="restoreFromSeed">
+            <p>
+              Enter your 12 word seed phrase, with a space between each word. Be sure you're doing
+              this in a private space. Anyone with these 12 words can steal your funds.
+            </p>
             <base-input
               v-model="seedPhrase"
               :autogrow="true"
               hint="Enter the your 12 word seed phrase"
-              label="Password"
+              label="Seed Phrase"
               style="min-width: 275px;"
             />
 
@@ -166,7 +170,7 @@ export default Vue.extend({
   methods: {
     readFile(file) {
       return new Promise((resolve, reject) => {
-        let reader = new FileReader();
+        const reader = new FileReader();
         reader.onload = () => {
           resolve(reader.result);
         };

--- a/src/pages/WalletRestore.vue
+++ b/src/pages/WalletRestore.vue
@@ -1,0 +1,161 @@
+<template>
+  <q-page padding class="text-primary text-center page-margin">
+    <!-- Home content -->
+    <div>
+      <p class="text-center">How would you like to restore your wallet?</p>
+      <div class="row justify-evenly q-mt-xl">
+        <base-button
+          class="col-auto"
+          :flat="true"
+          label="With Seed"
+          @click="showSeedRestore = true"
+        />
+        <base-button
+          class="col-auto"
+          :flat="true"
+          label="With File"
+          @click="showFileRestore = true"
+        />
+      </div>
+    </div>
+
+    <!-- Restore from file -->
+    <q-dialog v-model="showFileRestore">
+      <q-card class="q-px-lg">
+        <!-- Header Section -->
+        <q-card-section class="row items-center justify-between">
+          <q-btn icon="close" flat round dense style="opacity: 0; cursor: default;" />
+          <h6 class="text-primary q-my-none">Restore from File</h6>
+          <q-btn v-close-popup icon="close" color="primary" flat round dense />
+        </q-card-section>
+
+        <q-card-section class="q-pt-none">
+          <q-form @submit="decryptFile">
+            <q-file
+              accept=".dag"
+              outlined
+              v-model="seedFile"
+              hint="File must have a .dag extension"
+              label="Select File"
+            >
+              <template v-slot:prepend>
+                <q-icon name="attach_file" />
+              </template>
+            </q-file>
+
+            <base-input
+              v-if="seedFile"
+              v-model="password"
+              hint="Enter the password for this file"
+              :icon-append="isPasswordVisible ? 'fas fa-eye-slash' : 'fas fa-eye'"
+              label="Password"
+              :type="isPasswordVisible ? 'text' : 'password'"
+              @iconClicked="isPasswordVisible = !isPasswordVisible"
+            />
+
+            <div class="row justify-end q-mt-lg">
+              <base-button
+                class="col-auto"
+                color="primary"
+                :disabled="!isReadyToDecrypt"
+                label="Restore Wallet"
+                :loading="isLoading"
+                type="submit"
+              />
+            </div>
+          </q-form>
+        </q-card-section>
+      </q-card>
+    </q-dialog>
+
+    <!-- Restore from seed -->
+    <q-dialog v-model="showSeedRestore">
+      <q-card>
+        <!-- Header Section -->
+        <q-card-section class="row items-center justify-between">
+          <q-btn icon="close" flat round dense style="opacity: 0; cursor: default;" />
+          <h6 class="text-primary q-my-none">Restore from Seed</h6>
+          <q-btn v-close-popup icon="close" color="primary" flat round dense />
+        </q-card-section>
+
+        <q-card-section class="q-pt-none">
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Rerum repellendus sit voluptate
+          voluptas eveniet porro. Rerum blanditiis perferendis totam, ea at omnis vel numquam
+          exercitationem aut, natus minima, porro labore.
+        </q-card-section>
+
+        <q-card-actions align="right">
+          <q-btn flat label="OK" color="primary" v-close-popup />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+  </q-page>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import Wallet from 'src/wallet/Wallet';
+import helpers from 'src/utils/mixin-helpers';
+
+export default Vue.extend({
+  name: 'RestoreWallet',
+
+  mixins: [helpers],
+
+  data() {
+    return {
+      showFileRestore: false,
+      showSeedRestore: false,
+      seedFile: undefined,
+      isPasswordVisible: false,
+      password: undefined,
+      seedFileText: undefined,
+      isLoading: undefined,
+    };
+  },
+
+  computed: {
+    isReadyToDecrypt() {
+      return this.seedFileText && this.password;
+    },
+  },
+
+  watch: {
+    seedFile: {
+      async handler() {
+        const reader = new FileReader();
+        this.seedFileText = await this.readFile(this.seedFile);
+      },
+    },
+  },
+
+  methods: {
+    readFile(file) {
+      return new Promise((resolve, reject) => {
+        let reader = new FileReader();
+        reader.onload = () => {
+          resolve(reader.result);
+        };
+        reader.onerror = reject;
+        reader.readAsText(file);
+      });
+    },
+
+    async decryptFile() {
+      try {
+        this.isLoading = true;
+        const wallet = await Wallet.import(this.password, this.seedFileText);
+        // Save this info into local storage for later
+        this.$q.localStorage.set('kaspa-wallet-data', this.seedFileText);
+        // Since it was imported from a file, we know it's already backed up
+        this.$q.localStorage.set('is-backed-up', true);
+        await this.$store.dispatch('main/getWalletInfo', wallet);
+        await this.$router.push({ name: 'walletBalance' });
+      } catch (err) {
+        this.isLoading = false;
+        this.showError(err);
+      }
+    },
+  },
+});
+</script>

--- a/src/router/routes.ts
+++ b/src/router/routes.ts
@@ -11,6 +11,11 @@ const routes: RouteConfig[] = [
       { name: 'home', path: '', component: () => import('pages/WalletHandler.vue') },
       { name: 'createWallet', path: '/create', component: () => import('pages/WalletCreate.vue') },
       { name: 'openWallet', path: '/open', component: () => import('pages/WalletOpen.vue') },
+      {
+        name: 'restoreWallet',
+        path: '/restore',
+        component: () => import('pages/WalletRestore.vue'),
+      },
     ],
   },
   {


### PR DESCRIPTION
Closes #13

Changes are as described in #13. Other notes:
- Adds new `/restore` route. (Note that only the `/`, `/create`, `/open`, and `/restore` routes are visible without logging in)
- When restoring:
    - The encrypted seed phrase is stored in local storage
    - The `is-backed-up` flag in local storage is set to `true`, because if they have a file then it's already backed up

    