### PR TITLE
Add "send transaction" functionality

### DIFF
--- a/src/components/WalletBalanceTransactions.vue
+++ b/src/components/WalletBalanceTransactions.vue
@@ -2,7 +2,7 @@
   <div>
     <q-table
       :columns="columns"
-      :data="transactions"
+      :data="sortedTransactions"
       data-cy="wallet-balance-transactions"
       flat
       hide-header
@@ -135,6 +135,14 @@ export default Vue.extend({
       },
     }),
     /* eslint-enable */
+
+    /**
+     * @notice Returns confirmations sorted by number of confirmations, lowers first
+     */
+    sortedTransactions() {
+      // eslint-disable-next-line
+      return this.transactions.sort((a, b) => a.confirmations - b.confirmations);
+    },
   },
 
   methods: {
@@ -148,7 +156,8 @@ export default Vue.extend({
     },
 
     getConfirmationColor(numConfirmations: number) {
-      const confirmationRatio = this.getConfirmationRatio(numConfirmations);
+      // @ts-ignore
+      const confirmationRatio = Number(this.getConfirmationRatio(numConfirmations)); // eslint-disable-line @typescript-eslint/no-unsafe-call
       if (confirmationRatio >= 75) return 'positive';
       if (confirmationRatio < 75 && confirmationRatio >= 25) return 'warning';
       if (confirmationRatio < 25) return 'negative';

--- a/src/pages/WalletBalance.vue
+++ b/src/pages/WalletBalance.vue
@@ -22,7 +22,7 @@
         <q-spinner class="q-my-lg" color="primary" size="3em" />
       </div>
       <div class="text-center text-caption text-grey text-italic">
-        Fetching wallet data...
+        Fetching latest wallet data...
       </div>
     </div>
   </q-page>
@@ -71,8 +71,7 @@ export default Vue.extend({
   async mounted() {
     this.isLoading = true;
     this.getBackupStatus();
-    /* eslint-disable-next-line */
-    await this.wallet.addressDiscovery();
+    await this.wallet.updateState(); // eslint-disable-line
     await this.$store.dispatch('main/getWalletInfo', this.wallet);
     this.isLoading = false;
   },

--- a/src/pages/WalletSend.vue
+++ b/src/pages/WalletSend.vue
@@ -24,16 +24,19 @@ import Vue from 'vue';
 import { mapState } from 'vuex';
 // @ts-ignore
 import formatters from 'src/utils/mixin-formatters';
+// @ts-ignore
+import helpers from 'src/utils/mixin-helpers';
 
 export default Vue.extend({
   name: 'WalletSend',
 
-  mixins: [formatters],
+  mixins: [formatters, helpers],
 
   data() {
     return {
       toAddress: '',
       amount: '',
+      isLoading: false,
     };
   },
 
@@ -54,13 +57,23 @@ export default Vue.extend({
 
   methods: {
     async sendTransaction() {
-      // eslint-disable-next-line
-      const response = await this.wallet.sendTx({
-        toAddr: this.toAddress,
+      try {
+        this.isLoading = true;
+        // eslint-disable-next-line
+        const response = await this.wallet.sendTx({
+          toAddr: this.toAddress,
+          // @ts-ignore
+          amount: this.formatBalanceForMachine(this.amount), // eslint-disable-line
+        });
         // @ts-ignore
-        amount: this.formatBalanceForMachine(this.amount), // eslint-disable-line
-      });
-      console.log('response:', response);
+        this.notifyUser('positive', 'Your transaction has been sent!'); // eslint-disable-line
+        console.log('transactionId:', response);
+        await this.$router.push({ name: 'walletBalance' });
+      } catch (err) {
+        // @ts-ignore
+        this!.showError(err); // eslint-disable-line
+        this.isLoading = false;
+      }
     },
   },
 });

--- a/src/store/main/actions.ts
+++ b/src/store/main/actions.ts
@@ -4,7 +4,8 @@ import { MainStateInterface } from './state';
 
 const actions: ActionTree<MainStateInterface, StoreInterface> = {
   // eslint-disable-next-line
-  getWalletInfo({ commit }, wallet: any) {
+  async getWalletInfo({ commit }, wallet: any) {
+    await wallet.addressDiscovery(); // eslint-disable-line
     commit('setWalletInfo', wallet);
   },
 };

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -246,7 +246,7 @@ class Wallet {
     return id;
   }
 
-  async updateState(): void {
+  async updateState(): Promise<void> {
     await this.updateTransactions(Object.keys(this.addressManager.all));
     await this.updateUtxos(Object.keys(this.addressManager.all));
   }

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -237,16 +237,21 @@ class Wallet {
     const { id, rawTx } = this.composeTx(txParams);
     try {
       await api.postTx(rawTx);
-      await this.updateUtxos(Object.keys(this.addressManager.all));
-      this.deleteTx(id);
+      // await this.updateUtxos(Object.keys(this.addressManager.all));
+      this.deletePendingTx(id);
     } catch (e) {
-      this.deleteTx(id);
+      this.deletePendingTx(id);
       throw e;
     }
     return id;
   }
 
-  deleteTx(id: string): void {
+  async updateState(): void {
+    await this.updateTransactions(Object.keys(this.addressManager.all));
+    await this.updateUtxos(Object.keys(this.addressManager.all));
+  }
+
+  deletePendingTx(id: string): void {
     const { utxoIds } = this.pending.transactions[id];
     delete this.pending.transactions[id];
     this.utxoSet.release(utxoIds);

--- a/src/wallet/apiHelpers.ts
+++ b/src/wallet/apiHelpers.ts
@@ -17,7 +17,6 @@ export const getBlock = async (
   // eslint-disable-next-line
   const response = await fetch(`${apiEndpoint}/block/${blockHash}`, {
     mode: 'cors',
-    cache: 'no-cache',
   }).catch((e) => {
     throw new ApiError(`API connection error. ${e}`); // eslint-disable-line
   });
@@ -40,7 +39,6 @@ export const getTransactions = async (
       `${apiEndpoint}/transactions/address/${address}?limit=${n}&skip=${skip}`,
       {
         mode: 'cors',
-        cache: 'no-cache',
       }
     ).catch((e) => {
       throw new ApiError(`API connection error. ${e}`); // eslint-disable-line
@@ -68,7 +66,6 @@ export const getUtxos = async (
   // eslint-disable-next-line
   const response = await fetch(`${apiEndpoint}/utxos/address/${address}`, {
     mode: 'cors',
-    cache: 'no-cache',
   }).catch((e) => {
     throw new ApiError(`API connection error. ${e}`); // eslint-disable-line
   });
@@ -91,9 +88,7 @@ export const postTx = async (
     method: 'POST',
     mode: 'cors',
     cache: 'no-cache',
-    headers: {
-      ContentType: 'application/json',
-    },
+    headers: {},
     body: JSON.stringify({ rawTransaction }),
   }).catch((e) => {
     throw new ApiError(`API connection error. ${e}`); // eslint-disable-line

--- a/test/jest/__tests__/Wallet.utxoSet.test.js
+++ b/test/jest/__tests__/Wallet.utxoSet.test.js
@@ -30,7 +30,7 @@ test('UTXO set keeps a balance', () => {
   const balance1 = from.wallet.balance;
   expect(balance1).toEqual(balance0 - 7e7 - 1000);
   expect(utxoBalance1).toEqual(utxoBalance0 - 1e8);
-  from.wallet.deleteTx(tx1.id);
+  from.wallet.deletePendingTx(tx1.id);
   from.wallet.utxoSet.clear();
 });
 
@@ -54,8 +54,8 @@ test(`Wallet won't double compose UTXO`, async () => {
   expect(utxoBalance0 - from.wallet.utxoSet.utxos[tx1.utxoIds[0]].satoshis).toEqual(utxoBalance1);
   expect(utxoBalance1 === utxoBalance2).toBe(false);
   expect(utxoBalance1 - from.wallet.utxoSet.utxos[tx2.utxoIds[0]].satoshis).toEqual(utxoBalance2);
-  from.wallet.deleteTx(tx1.id);
-  from.wallet.deleteTx(tx2.id);
+  from.wallet.deletePendingTx(tx1.id);
+  from.wallet.deletePendingTx(tx2.id);
   from.wallet.utxoSet.clear();
 });
 
@@ -75,7 +75,7 @@ test(`Utxo set can account for aborted transactions`, () => {
   expect(balance1).toEqual(balance0 - 7e7 - 1000);
   expect(utxoBalance0 === utxoBalance1).toBe(false);
   expect(from.wallet.utxoSet.inUse.length).toBe(1);
-  from.wallet.deleteTx(tx1.id);
+  from.wallet.deletePendingTx(tx1.id);
   expect(from.wallet.utxoSet.availableBalance).toEqual(utxoBalance0);
   expect(from.wallet.utxoSet.inUse.length).toBe(0);
 });


### PR DESCRIPTION
Resolves #54
Resolves #57  

Changes:
- Fix API requests to work with kasparovd
- Send tabs now lets you send transactions
- Toasts displayed on success and failure
- Balance page now sorts transactions by number of confirmations